### PR TITLE
feat: SHAKE via shared swift-goldilocks on Android/Wasm

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 1.1.0 (2026-05-28)
+
+### Feat
+
+- SHAKE via shared swift-goldilocks on Android/Wasm
+
 ## 1.0.1 (2026-05-28)
 
 ### Feat

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "1bde4788bde3efb2865da0e4e0c81e08808cbf4a0b4f2027de5fe04ab9a3a581",
+  "originHash" : "7dcb02e9e940457c0bfa9472bc8cf14863902cf5b4610060de7ae1e088a15ed6",
   "pins" : [
     {
       "identity" : "bigint",
@@ -87,8 +87,17 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Kingpin-Apps/swift-curve448.git",
       "state" : {
-        "revision" : "ef66c48dca773258090ae17e1cc4fb3c15cf2a44",
-        "version" : "0.2.1"
+        "revision" : "22485969852eeaf1160a8287fe2783607bde4d2d",
+        "version" : "0.2.2"
+      }
+    },
+    {
+      "identity" : "swift-goldilocks",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/Kingpin-Apps/swift-goldilocks.git",
+      "state" : {
+        "revision" : "ae27bd2b74963107909f9bd5c9d1fbd4d0e0acbe",
+        "version" : "0.1.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -25,8 +25,12 @@ let package = Package(
         .package(url: "https://github.com/krzyzanowskim/OpenSSL-Package.git", .upToNextMinor(from: "3.3.2000")),
         .package(url: "https://github.com/21-DOT-DEV/swift-secp256k1", from: "0.22.0"),
         .package(url: "https://github.com/krzyzanowskim/CryptoSwift.git", .upToNextMinor(from: "1.9.0")),
-        .package(url: "https://github.com/Kingpin-Apps/swift-curve448.git", from: "0.2.1"),
+        .package(url: "https://github.com/Kingpin-Apps/swift-curve448.git", from: "0.2.2"),
         .package(url: "https://github.com/Kingpin-Apps/swift-cbor-codable.git", from: "0.3.1"),
+        // Shared libgoldilocks vendor for SHAKE128/256 on platforms without a
+        // usable libcrypto (Android + Wasm). Same package swift-curve448 uses
+        // for Ed448/X448 — no duplicate vendoring.
+        .package(url: "https://github.com/Kingpin-Apps/swift-goldilocks.git", from: "0.1.0"),
     ],
     targets: [
         // System libcrypto on Linux — provides the same `BN_*` symbols that
@@ -57,7 +61,14 @@ let package = Package(
                 ),
                 .target(
                     name: "CCOSEOpenSSL",
-                    condition: .when(platforms: [.linux, .android])
+                    condition: .when(platforms: [.linux])
+                ),
+                // SHAKE128/256 via libgoldilocks on Android + Wasm (no usable
+                // libcrypto). Self-contained — has its own Keccak/SHAKE impl.
+                .product(
+                    name: "Goldilocks",
+                    package: "swift-goldilocks",
+                    condition: .when(platforms: [.android, .wasi])
                 ),
                 .product(name: "P256K", package: "swift-secp256k1"),
                 .product(name: "SwiftCurve448", package: "swift-curve448"),

--- a/Sources/SwiftCOSE/Algorithms/HashAlgorithm.swift
+++ b/Sources/SwiftCOSE/Algorithms/HashAlgorithm.swift
@@ -11,6 +11,9 @@ import OpenSSL
 #if canImport(CCOSEOpenSSL)
 import CCOSEOpenSSL
 #endif
+#if canImport(Goldilocks)
+import Goldilocks
+#endif
 
 public class HashAlgorithm: CoseAlgorithm {
     public var hashAlgorithm: CoseAlgorithmIdentifier
@@ -89,8 +92,18 @@ public class HashAlgorithm: CoseAlgorithm {
             throw CoseError.invalidAlgorithm("EVP_DigestFinalXOF failed for SHAKE")
         }
         return output
+        #elseif canImport(Goldilocks)
+        // libgoldilocks SHAKE — used on platforms without OpenSSL EVP
+        // (currently Android and Wasm). Self-contained Keccak impl shared
+        // with swift-curve448 via the swift-goldilocks package.
+        switch variant {
+        case .shake128:
+            return Goldilocks.SHAKE128.hash(data, outputByteCount: outputBytes)
+        case .shake256:
+            return Goldilocks.SHAKE256.hash(data, outputByteCount: outputBytes)
+        }
         #else
-        throw CoseError.invalidAlgorithm("SHAKE is unavailable on this platform (no OpenSSL EVP)")
+        throw CoseError.invalidAlgorithm("SHAKE is unavailable on this platform (no OpenSSL EVP, no Goldilocks)")
         #endif
     }
 }

--- a/Sources/SwiftCOSE/Keys/RSAKey.swift
+++ b/Sources/SwiftCOSE/Keys/RSAKey.swift
@@ -221,7 +221,13 @@ public class RSAKey: CoseKey {
         guard keyBits % 8 == 0 else {
             throw CoseError.invalidKey("Invalid key length")
         }
-        
+
+        // RSA prime generation uses OpenSSL/libcrypto's BN_generate_prime_ex
+        // (via BigUInteger.getPrime in Utils/Extensions.swift). Not yet
+        // implemented for platforms without libcrypto (Android, Wasm).
+        #if !(canImport(OpenSSL) || canImport(CCOSEOpenSSL))
+        throw CoseError.invalidKey("RSA key generation requires OpenSSL/libcrypto, unavailable on this platform")
+        #else
         // Generate prime numbers
         let p = try BigUInteger.getPrime(keyBits / 2)!
         let q = try BigUInteger.getPrime(keyBits / 2)!
@@ -252,8 +258,9 @@ public class RSAKey: CoseKey {
             extKey: extKey,
             optionalParams: additionalParams
         )
+        #endif
     }
-    
+
     /// Returns an initialized COSE Key object of type RSAKey.
     /// - Parameter coseKey: Dict containing COSE Key parameters and there values.
     /// - Returns: An initialized RSAKey key.

--- a/Sources/SwiftCOSE/Utils/Extensions.swift
+++ b/Sources/SwiftCOSE/Utils/Extensions.swift
@@ -9,9 +9,12 @@ import CBORCodable
 import CryptoSwift
 #if canImport(OpenSSL)
 import OpenSSL
-#else
+#elseif canImport(CCOSEOpenSSL)
 import CCOSEOpenSSL
 #endif
+// Note: on platforms without OpenSSL/libcrypto (Android, Wasm), neither
+// module imports — RSA prime generation below is conditionally compiled
+// out and RSAKey.generateKey() throws at runtime there.
 
 
 // MARK: - Curve25519.KeyAgreement.PublicKey Extensions
@@ -257,25 +260,26 @@ extension RSA {
 
 // MARK: CS.BigUInt extension
 
+#if canImport(OpenSSL) || canImport(CCOSEOpenSSL)
 extension BigUInteger {
 
   public static func getPrime(_ bits: Int = 1024) throws -> BigUInteger? {
       let bn = BN_new()       // Create a new BIGNUM object
       let ctx = BN_CTX_new()  // Create a new BN context for calculations
-      
+
       defer {
           BN_free(bn)
           BN_CTX_free(ctx)
       }
-      
+
       // Generate a prime number with the specified bit length
       if BN_generate_prime_ex(bn, Int32(bits), 1, nil, nil, nil) == 1 {
           // Get the raw bytes from BIGNUM
          let byteCount = (BN_num_bits(bn) + 7) / 8
           var buffer = [UInt8](repeating: 0, count: Int(byteCount))
-         
+
          BN_bn2bin(bn, &buffer)
-         
+
          // Convert to BigUInteger directly from bytes
          return BigUInteger(Data(buffer))
       } else {
@@ -283,3 +287,4 @@ extension BigUInteger {
       }
   }
 }
+#endif

--- a/cz.toml
+++ b/cz.toml
@@ -1,3 +1,3 @@
 [tool.commitizen]
-version = "1.0.1"
+version = "1.1.0"
 update_changelog_on_bump = true


### PR DESCRIPTION
## Summary

Adds a third SHAKE128/256 branch to \`HashAlgorithm.evpShake()\` that uses [swift-goldilocks](https://github.com/Kingpin-Apps/swift-goldilocks)'s \`Goldilocks.SHAKE128\` / \`SHAKE256\` wrappers on platforms without OpenSSL EVP. Same libgoldilocks code swift-curve448 (0.2.2) now depends on — no duplicate vendoring across packages.

Also fixes the remaining Android compile errors that the original CCOSEOpenSSL-on-Android wiring couldn't handle:

- **Package.swift**: drop \`CCOSEOpenSSL\` from \`.android\` (keep \`.linux\` only); add \`Goldilocks\` product on \`[.android, .wasi]\`; bump \`swift-curve448\` to \`0.2.2\` so we inherit the deduped libgoldilocks vendor.
- **Utils/Extensions.swift**: make \`CCOSEOpenSSL\` import conditional via \`#elseif canImport(...)\`; wrap \`BigUInteger.getPrime\` (which uses \`BN_*\`) in the same guard so the file compiles when no libcrypto is available.
- **Keys/RSAKey.swift**: conditionally compile \`RSAKey.generateKey\` body; throw a clear runtime error on platforms without libcrypto rather than failing to compile.

## Test plan

- [x] \`swift build\` green on macOS
- [x] \`swift test\` — all 284 tests pass
- [x] SPI matrix Swift 6.1: **android ✓**, linux ✓
- [ ] Wasm stays ✗ — unrelated upstream issue (\`swift-crypto/_CryptoExtras/Util/ThreadSpecific/ThreadSpecific.swift\` references \`ThreadOpsSystem\` types that don't resolve under the wasm SDK). Out of scope; tracked separately.
- [ ] Optional: full 4-Swift × 9-platform SPI matrix before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)